### PR TITLE
Feature/3 calendar api

### DIFF
--- a/demo/.gitignore
+++ b/demo/.gitignore
@@ -38,3 +38,6 @@ out/
 
 # API 키 설정 파일 제외
 src/main/resources/application-api-key.yml
+
+# db 설정 파일 제외
+src/main/resources/application.yml

--- a/demo/src/main/java/book_log/demo/controller/CalendarController.java
+++ b/demo/src/main/java/book_log/demo/controller/CalendarController.java
@@ -1,6 +1,7 @@
 package book_log.demo.controller;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -8,11 +9,14 @@ import org.springframework.web.bind.annotation.RestController;
 
 import book_log.demo.dto.response.CalendarResponse;
 import book_log.demo.service.CalendarService;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/api/calendar")
 @RequiredArgsConstructor
+@Validated // 클래스 레벨에 추가하여 파라미터 검증 활성화
 public class CalendarController {
     
     private final CalendarService calendarService;
@@ -23,8 +27,8 @@ public class CalendarController {
      */
     @GetMapping("/activities")
     public ResponseEntity<CalendarResponse> getMonthlyActivity(
-        @RequestParam(name = "year") int year,
-        @RequestParam(name = "month") int month
+        @RequestParam(name = "year") @Min(2000) @Max(2100) int year,
+        @RequestParam(name = "month") @Min(1) @Max(12) int month
         // 실제 서비스 시에는 @AuthenticationPrincipal 등을 통해 로그인한 유저 ID 가져오기
     ) {
         // 임시로 유저 ID를 1L로 설정 (로그인 구현 방식 따라 변경 필요)

--- a/demo/src/main/java/book_log/demo/controller/CalendarController.java
+++ b/demo/src/main/java/book_log/demo/controller/CalendarController.java
@@ -1,0 +1,38 @@
+package book_log.demo.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import book_log.demo.dto.response.CalendarResponse;
+import book_log.demo.service.CalendarService;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/calendar")
+@RequiredArgsConstructor
+public class CalendarController {
+    
+    private final CalendarService calendarService;
+
+    /**
+     * 월별 활동 기록 조회 API
+     * GET /api/calendar/activities?year=2026&month=4
+     */
+    @GetMapping("/activities")
+    public ResponseEntity<CalendarResponse> getMonthlyActivity(
+        @RequestParam(name = "year") int year,
+        @RequestParam(name = "month") int month
+        // 실제 서비스 시에는 @AuthenticationPrincipal 등을 통해 로그인한 유저 ID 가져오기
+    ) {
+        // 임시로 유저 ID를 1L로 설정 (로그인 구현 방식 따라 변경 필요)
+        Long userId = 1L;
+
+        CalendarResponse response = calendarService.getMonthlyActivity(userId, year, month);
+
+        return ResponseEntity.ok(response);
+    }
+
+}

--- a/demo/src/main/java/book_log/demo/domain/Content.java
+++ b/demo/src/main/java/book_log/demo/domain/Content.java
@@ -28,6 +28,10 @@ public class Content extends BaseTimeEntity{
     private Double rating;
     private LocalDate viewDate;
 
+    // 임시
+    @Column(name = "user_id")
+    private Long userId = 1L;
+
     @Column(columnDefinition = "TEXT")
     private String comment; // 사용자의 상세 감상평 (길어질 수 있으므로 TEXT)
 

--- a/demo/src/main/java/book_log/demo/dto/response/CalendarResponse.java
+++ b/demo/src/main/java/book_log/demo/dto/response/CalendarResponse.java
@@ -1,0 +1,24 @@
+package book_log.demo.dto.response;
+
+import java.util.List;
+
+public record CalendarResponse(
+    int year,
+    int month,
+    List<DayActivity> days
+) {
+    /**
+     * 날짜별 활동 정보를 담는 레코드
+     * 지금은 day만 사용하지만, 나중에 thumbnail, contentId 등을 추가하여 확장
+     */
+    public record DayActivity(
+        int day, // 기록이 있는 날짜 (점을 찍어야 할 날짜들의 목록)
+        String thumbnail, // 추후 메인 기능용 (현재는 null)
+        Long count // 해당 날짜에 쓴 글 개수
+    ) {
+        // 사이드바 점 찍기용 생성자
+        public static DayActivity of(int day) {
+            return new DayActivity(day, null, null);
+        }
+    }
+}

--- a/demo/src/main/java/book_log/demo/repository/ContentRepository.java
+++ b/demo/src/main/java/book_log/demo/repository/ContentRepository.java
@@ -32,11 +32,11 @@ public interface ContentRepository extends JpaRepository<Content, Long> {
 
     // 사이드바 미니 캘린더용 : 특정 월의 기록이 있는 날짜 리스트 조회
     @Query(value = """ 
-        SELECT DISTINCT CAST(EXTRACT(DAY FROM c.created_at) AS INTEGER)
+        SELECT DISTINCT CAST(EXTRACT(DAY FROM c.view_date) AS INTEGER)
         FROM content c 
         WHERE c.user_id = :userId 
-          AND EXTRACT(YEAR FROM c.created_at) = :year 
-          AND EXTRACT(MONTH FROM c.created_at) = :month
+          AND EXTRACT(YEAR FROM c.view_date) = :year 
+          AND EXTRACT(MONTH FROM c.view_date) = :month
         ORDER BY 1
         """, nativeQuery = true)
     List<Integer> findActiveDays(

--- a/demo/src/main/java/book_log/demo/repository/ContentRepository.java
+++ b/demo/src/main/java/book_log/demo/repository/ContentRepository.java
@@ -30,4 +30,18 @@ public interface ContentRepository extends JpaRepository<Content, Long> {
     // 3. 카테고리로만 필터링
     List<Content> findByCategory(Category category);
 
+    // 사이드바 미니 캘린더용 : 특정 월의 기록이 있는 날짜 리스트 조회
+    @Query(value = """ 
+        SELECT DISTINCT CAST(EXTRACT(DAY FROM c.created_at) AS INTEGER)
+        FROM content c 
+        WHERE c.user_id = :userId 
+          AND EXTRACT(YEAR FROM c.created_at) = :year 
+          AND EXTRACT(MONTH FROM c.created_at) = :month
+        ORDER BY 1
+        """, nativeQuery = true)
+    List<Integer> findActiveDays(
+        @Param("userId") Long userId,
+        @Param("year") int year,
+        @Param("month") int month
+    );
 }

--- a/demo/src/main/java/book_log/demo/service/CalendarService.java
+++ b/demo/src/main/java/book_log/demo/service/CalendarService.java
@@ -1,0 +1,35 @@
+package book_log.demo.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import book_log.demo.dto.response.CalendarResponse;
+import book_log.demo.repository.ContentRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CalendarService {
+    
+    private final ContentRepository contentRepository;
+
+    // 특정 월의 활동 기록 날짜 조회
+    @Transactional(readOnly = true)
+    public CalendarResponse getMonthlyActivity(Long userId, int year, int month) {
+        
+        // 1. 리포지토리에서 day 리스트 가져오기
+        List<Integer> activeDays = contentRepository.findActiveDays(userId, year, month);
+
+        // 2. 숫자 리스트를 DayActivity 객체 리스트로 반환(Java Stream 활용)
+        List<CalendarResponse.DayActivity> dayActivities = activeDays.stream()
+                .map(day -> new CalendarResponse.DayActivity(day, null, null))
+                .toList();
+
+        // 3. 최종 응답 DTO 생성 및 반환
+        return new CalendarResponse(year, month, dayActivities);
+
+    }
+
+}

--- a/demo/src/main/resources/application.yml
+++ b/demo/src/main/resources/application.yml
@@ -4,24 +4,17 @@ spring:
   profiles:
     include: api-key  # application-api-key.yml 가져옴
     
-  # 데이터베이스 설정 (H2 메모리 DB)
   datasource:
-    url: jdbc:h2:mem:testdb
-    driver-class-name: org.h2.Driver
-    username: sa
-    password:
+    url: jdbc:postgresql://aws-1-ap-northeast-1.pooler.supabase.com:5432/postgres
+    username: postgres.odlfedzyieuplylcggzb
+    password: "toothag0624!"
+    driver-class-name: org.postgresql.Driver
 
-  # H2 콘솔 설정 (브라우저에서 DB 확인용)
-  h2:
-    console:
-      enabled: true
-      path: /h2-console
-
-  # JPA / Hibernate 설정
   jpa:
     hibernate:
-      ddl-auto: update # 엔티티 기반으로 테이블 자동 생성
-    show-sql: true     # 실행되는 SQL을 터미널에 출력
+      ddl-auto: update # 테이블 자동 생성 (개발 초기용)
+    show-sql: true
     properties:
       hibernate:
-        format_sql: true # SQL을 보기 좋게 정렬
+        format_sql: true
+        dialect: org.hibernate.dialect.PostgreSQLDialect

--- a/demo/src/main/resources/application.yml
+++ b/demo/src/main/resources/application.yml
@@ -5,9 +5,9 @@ spring:
     include: api-key  # application-api-key.yml 가져옴
     
   datasource:
-    url: jdbc:postgresql://aws-1-ap-northeast-1.pooler.supabase.com:5432/postgres
+    # IPv4 환경에서는 반드시 pooler 주소와 6543 포트를 써야 함
+    url: jdbc:postgresql://aws-1-ap-northeast-1.pooler.supabase.com:6543/postgres?prepareThreshold=0
     username: postgres.odlfedzyieuplylcggzb
-    password: "toothag0624!"
     driver-class-name: org.postgresql.Driver
 
   jpa:
@@ -17,4 +17,3 @@ spring:
     properties:
       hibernate:
         format_sql: true
-        dialect: org.hibernate.dialect.PostgreSQLDialect

--- a/demo/src/test/java/book_log/demo/repository/HighlightRepositoryTest.java
+++ b/demo/src/test/java/book_log/demo/repository/HighlightRepositoryTest.java
@@ -1,0 +1,144 @@
+package book_log.demo.repository;
+
+// JUnit 5 (테스트 프레임워크)
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+// AssertJ (검증 라이브러리)
+import static org.assertj.core.api.Assertions.assertThat;
+
+// Spring Boot Test (JPA 테스트용)
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.ContextConfiguration;
+
+import book_log.demo.DemoApplication;
+// 엔티티들 (패키지 경로 확인 필요!)
+import book_log.demo.domain.Content;
+import book_log.demo.domain.Highlight;
+
+import java.util.List;
+// Java 기본 유틸
+import java.util.Optional;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+// DemoApplication 대신, 테스트에 꼭 필요한 '최소 단위'만 명시합니다.
+@ContextConfiguration(classes = {
+    HighlightRepository.class,
+    ContentRepository.class
+})
+// 엔티티 패키지 경로를 직접 짚어줍니다.
+@EntityScan(basePackages = "book_log.demo.domain")
+// 레포지토리 패키지 경로를 직접 짚어줍니다.
+@EnableJpaRepositories(basePackages = "book_log.demo.repository")
+class HighlightRepositoryTest {
+
+    @Autowired
+    private HighlightRepository highlightRepository;
+
+    @Autowired
+    private ContentRepository contentRepository;
+
+    @Test
+    @DisplayName("하이라이트 저장 및 조회 테스트")
+    void saveAndFindHighlight() {
+        // 1. Given: 테스트 데이터 준비 (연관된 Content가 먼저 있어야 함)
+        Content content = Content.builder()
+                .title("테스트 책")
+                .authorOrDirector("은서")
+                .build();
+        contentRepository.save(content);
+
+        Highlight highlight = Highlight.builder()
+                .text("오늘의 한 문장")
+                .page(123)
+                .content(content)
+                .build();
+
+        // 2. When: 저장
+        Highlight savedHighlight = highlightRepository.save(highlight);
+
+        // 3. Then: 검증
+        Highlight foundHighlight = highlightRepository.findById(savedHighlight.getId()).orElseThrow();
+        assertThat(foundHighlight.getText()).isEqualTo("오늘의 한 문장");
+        assertThat(foundHighlight.getContent().getTitle()).isEqualTo("테스트 책");
+    }
+
+    @Test
+    @DisplayName("하이라이트 내용이 null이면 저장에 실패해야 한다")
+    void saveHighlightWithNullTest() {
+        // Given
+        Highlight highlight = Highlight.builder()
+                .text(null) // 필수값인 text를 null로 설정
+                .build();
+
+        // when & then
+        // DB 제약 조건 위반 예외가 발생하는지 검증
+        org.junit.jupiter.api.Assertions.assertThrows(org.springframework.dao.DataIntegrityViolationException.class, () -> {highlightRepository.saveAndFlush(highlight);
+            // saveAndFlush를 써야 즉시 DB에 반영되어 예외가 발생
+        });
+    }
+
+    @Test
+    @DisplayName("특정 컨텐츠의 하이라이트 목록만 조회한다")
+    void findByContentId() {
+        // given
+        Content content1 = contentRepository.save(Content.builder().title("책 1").build());
+        Content content2 = contentRepository.save(Content.builder().title("책 2").build());
+
+        highlightRepository.save(Highlight.builder().text("문장 1").content(content1).build());
+        highlightRepository.save(Highlight.builder().text("문장 2").content(content1).build());
+        highlightRepository.save(Highlight.builder().text("문장 3").content(content2).build());
+
+        // when
+        List<Highlight> result = highlightRepository.findByContentId(content1.getId());
+
+        // then
+        assertThat(result).hasSize(2); // content1에 속한 2개만 나와야 함
+        assertThat(result).extracting("text").containsExactlyInAnyOrder("문장 1", "문장 2");
+    }
+
+    @Test
+    @DisplayName("하이라이트 내용을 수정하면 DB에 반영되어야 한다")
+    void updateHighlight() {
+        // given
+        Highlight highlight = highlightRepository.save(Highlight.builder().text("원래 내용").build());
+
+        // when
+        highlight.update("수정된 내용", 10, 1, 1, "00:10:00");
+        highlightRepository.saveAndFlush(highlight); // 변경 사항 강제 반영
+
+        // then
+        Highlight updated = highlightRepository.findById(highlight.getId()).orElseThrow();
+        assertThat(updated.getText()).isEqualTo("수정된 내용");
+    }
+
+    @Test
+    @DisplayName("컨텐츠를 삭제하면 연관된 하이라이트 처리 확인")
+    void deleteContentAndCheckHighlight() {
+        // given
+        Content content = contentRepository.save(Content.builder().title("지워질 책").build());
+        Highlight highlight = Highlight.builder()
+            .text("함께 지워질까?")
+            .content(content) // 여기서 content는 이제 'Saved' 상태입니다.
+            .build();
+
+        highlightRepository.save(highlight);
+
+        // when
+        contentRepository.delete(content);
+        contentRepository.flush();
+
+        // then
+        // CascadeType.REMOVE 설정이 되어있다면 하이라이트도 0개가 되어야 함
+        List<Highlight> result = highlightRepository.findByContentId(content.getId());
+        assertThat(result).isEmpty();
+    }
+}

--- a/demo/src/test/java/book_log/demo/service/CalendarServiceTest.java
+++ b/demo/src/test/java/book_log/demo/service/CalendarServiceTest.java
@@ -1,0 +1,89 @@
+package book_log.demo.service;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import static org.mockito.BDDMockito.given;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import book_log.demo.dto.response.CalendarResponse;
+import book_log.demo.repository.ContentRepository;
+
+@ExtendWith(MockitoExtension.class)
+public class CalendarServiceTest {
+    
+    @InjectMocks
+    private CalendarService calendarService;
+
+    @Mock
+    private ContentRepository contentRepository;
+
+    @Test
+    @DisplayName("조회된 날짜 리스트를 CalendarResponse DTO로 변환")
+    void getMonthlyActivityTest() {
+        // given
+        Long userId = 1L;
+        int year = 2026;
+        int month = 4;
+
+        // Mock 객체의 동작 정의
+        given(contentRepository.findActiveDays(userId, year, month))
+                .willReturn(List.of(4,10,15));
+
+        // when (실제 서비스 호출)
+        CalendarResponse response = calendarService.getMonthlyActivity(userId, year, month);
+
+        // then (검증)
+        assertThat(response.year()).isEqualTo(year);
+        assertThat(response.month()).isEqualTo(month);
+        assertThat(response.days()).hasSize(3);
+        assertThat(response.days().get(0).day()).isEqualTo(4);
+    }
+
+    @Test
+    @DisplayName("기록이 없는 달을 조회하면 빈 리스트를 포함한 DTO 반환")
+    void getMonthlyActivityEmptyTest() {
+        //given
+        Long userId = 1L;
+        int year = 2026;
+        int month = 1; // 기록이 없는 달 가정
+
+        given(contentRepository.findActiveDays(userId, year, month))
+                .willReturn(List.of()); // 빈 리스트 반환
+
+        // when
+        CalendarResponse response = calendarService.getMonthlyActivity(userId, year, month);
+
+        // then
+        assertThat(response.days()).isEmpty();
+        assertThat(response.year()).isEqualTo(year);
+    }
+
+    @Test
+    @DisplayName("리스트의 모든 날짜가 정확하게 DayActivity로 매핑된다")
+    void getMonthlyActivityMappingTest() {
+        //given
+        List<Integer> mockDays = List.of(1,15,30);
+
+        given(contentRepository.findActiveDays(1L, 2026, 4))
+                .willReturn(mockDays);
+
+        // when
+        CalendarResponse response = calendarService.getMonthlyActivity(1L, 2026, 4);
+
+        // then
+        // 리스트 내의 day 값들만 추출해서 비교
+        List<Integer> actualDays = response.days().stream()
+                .map(CalendarResponse.DayActivity::day)
+                .toList();
+
+        assertThat(actualDays).containsExactly(1,15,30);
+    }
+
+}


### PR DESCRIPTION
## 📌 개요
기능: 미디어 기록 시각화를 위한 캘린더 서비스 및 콘텐츠 필터링 API 구현

인프라: Supabase DB 연결 안정화 및 멀티 프로파일 설정을 통한 보안 강화

## 🛠️ 작업 내용
**[캘린더] 월별 활동 날짜 조회 기능 (CalendarController, Service)**

- CalendarResponse 레코드 구조 설계: 현재는 점 찍기용 day만 반환하지만, 추후 확장성(썸네일 등)을 고려한 내부 DayActivity 구조 채택

- @Validated를 활용한 연도(2000-2100) 및 월(1-12) 파라미터 유효성 검사 추가

**[콘텐츠] 다중 조건 필터링 API (ContentController, Service)**

- 연도와 카테고리를 조합한 동적 필터링 로직 구현 (둘 다 있음 / 연도만 / 카테고리만 / 전체 조회)

- 중복 저장 방지를 위해 externalId와 Category를 이용한 중복 체크 로직 적용

**[DB/보안] 데이터 매핑 및 보안 설정**

- 네이티브 쿼리 최적화: PostgreSQL EXTRACT 함수를 사용하여 view_date 기준의 활동 일자를 중복 없이(DISTINCT) 추출

- 유저 식별 기반 마련: userId 필드를 엔티티와 쿼리에 선제적으로 반영 (현재 1L 고정 사용)

- 환경 설정: api-key 프로파일 분리를 통해 민감한 접속 정보 보호 및 Supabase Session Pooler 연결 완료

## 🧪 테스트 결과
- [x] API 테스트: GET /api/calendar/activities 호출 시, viewDate가 일치하는 데이터들의 날짜가 JSON 배열로 정상 반환됨을 확인

- [x] 필터링 테스트: 특정 연도나 카테고리로 조회 시 해당되는 콘텐츠 리스트만 정확히 필터링됨을 확인

- [x] 중복 체크: 이미 저장된 externalId가 있는 콘텐츠 저장 시도 시 IllegalStateException 발생 확인